### PR TITLE
added ls command, added add_command and remove_command() method

### DIFF
--- a/bot.c
+++ b/bot.c
@@ -94,22 +94,6 @@ char* returnCommand(char* strinput){
 }
 
 //TODO 35: add GOTO for failing conditions
-int writeToFile(char* command, char* body){
-  FILE* f = fopen("commands.csv", "a");
-  if (f == NULL){
-    perror("error: couldn't open commands.csv");
-    fclose(f);
-    return -1;
-  }
-  if(fprintf(f, "%s,%s\n", command, body)==-1){
-    perror("couldn't write to file");
-    fclose(f);
-    return -1;
-  }
-  fclose(f);
-  return 0;
-};
-
 //returns the sender of a twitch chat command, expects line of twitch chat 
 char* commandSender(char* strinput){
   char* tok = strtok(strinput, "!"); //expected input: :usr!usr@usr.tmi.twitch.tv PRIVMSG #chan :msg
@@ -184,7 +168,7 @@ int analyseInput(char* strinput){
     }
     printf("removed command '%s'\n", commandName);
     return 0;
-  }else if(strncmp(token, "addcmd", 6)==0){
+  }else if(strcmp(token, "addcmd")==0){
 
     if(strlen(strinput2)<=7){ //checks for arguments
       printf("addcmd <command> <message>\n");
@@ -200,24 +184,17 @@ int analyseInput(char* strinput){
       printf("Error: command '%s' already exists\n", commandName);
       return 0;
     }
-    char body[strlen(strinput)-strlen(commandName)-6]; //char body has to be size of command body, so total length - length of commandName - length of strin 'addcmd' (6)
-    token = strtok(NULL, " ");
-    sprintf(body, ""); 
-    while(token != NULL){
-      sprintf(body, "%s ", strcat(body, token));
-      token = strtok(NULL, " ");
-    }
-    body[strlen(body)-2] = 0;
+
+    char* body = strchr(strinput2, ' ');
+    body++;
+    body = strchr(body, ' ');
+    body++; //all of this just gets the pointer to string after the first two spaces
+    
     if(strlen(commandName)==1 || strlen(body)==0){
       printf("addcmd <command> <message>\n");
       return 0;
     }
-    if(writeToFile(commandName, body)==-1){
-      return -1;
-    }
-    //TODO 34: hacky way to add new command to struct of commands
-    finish();
-    init();
+    add_command(commandName, body);
     return 0;
   }
   return -2;

--- a/lib/cmdfile.c
+++ b/lib/cmdfile.c
@@ -43,8 +43,6 @@ int init() {
         int cmdSize = strcspn(buffer, ",")+2;
 	int msgSize = lineSize-cmdSize-1;
 
-        //fprintf(stderr, "Buffer: \"%s\"\n\tlinesize: %d\t cmdSize: %d\t msgSize: %d\n", buffer, lineSize, cmdSize, msgSize);
-
         tmp->cmd = (char *)malloc(sizeof(char)*cmdSize);
         tmp->msg = (char *)malloc(sizeof(char)*msgSize); 
 	sscanf(buffer, "%[^,],%[^\n]", tmp->cmd, tmp->msg);
@@ -98,6 +96,19 @@ int remove_command(char* remove_cmd){
   return 0;
 }
 
+int add_command(char* add_cmd, char* add_msg){
+  lines++;
+  Commands* tmp = (Commands *)realloc(allCommands, sizeof(Commands)*lines);
+  Commands* lastcmd = (tmp + cmdlen);
+  lastcmd->cmd = (char *)malloc(strlen(add_cmd));
+  lastcmd->msg = (char *)malloc(strlen(add_msg));
+  strcpy(lastcmd->cmd, add_cmd);
+  strcpy(lastcmd->msg, add_msg);
+  allCommands = tmp;
+  cmdlen++;
+  return 0;
+}
+
 void list_bot_commands(){ //for debugging
   int i;
   Commands* tmp = allCommands;
@@ -108,13 +119,21 @@ void list_bot_commands(){ //for debugging
 }
 
 int finish() {
-    int i;
-    for(i = 0; i < cmdlen; i++) {
-        Commands *curr = (allCommands + i);
-        free(curr->cmd);
-        free(curr->msg);
+  int i;
+  FILE* fp = fopen("commands.csv", "w");
+  if(fp==NULL){
+    printf("couldn't open commands.csv\n");
+    return -1;
+  }
+  for(i = 0; i < cmdlen; i++) {
+    Commands *curr = (allCommands + i);
+    if(fprintf(fp, "%s,%s\n", curr->cmd, curr->msg) < 0){
+      printf("failed to save command `%s`\n", curr->cmd);
     }
-
-    free(allCommands);
-    return 0;
+    free(curr->cmd);
+    free(curr->msg);
+  }
+  free(allCommands);
+  fclose(fp);
+  return 0;
 }

--- a/lib/cmdfile.c
+++ b/lib/cmdfile.c
@@ -12,6 +12,8 @@ typedef struct {
 Commands *allCommands;
 int cmdlen;
 
+int lines = 0;
+
 #define cmdFile "commands.csv"
 #define MAX_LEN 4096
 
@@ -26,7 +28,6 @@ int init() {
         return -1;
 
     char buffer[MAX_LEN + 1];
-    int lines = 0;
 
     //count number of lines in file
     while(fgets(buffer, MAX_LEN, fp) != NULL)
@@ -34,7 +35,6 @@ int init() {
     
     //reset position in file to beginning
     fseek(fp, 0, SEEK_SET);
-
     allCommands = (Commands *)malloc(sizeof(Commands)*lines);
     Commands *tmp = allCommands;
     cmdlen = 0;
@@ -76,6 +76,36 @@ int test_command(const char *test_cmd, char *outputMsg, int maxOutputLen) {
   return 0;
 }
 
+int remove_command(char* remove_cmd){
+  int i;
+  Commands* tmp = allCommands;
+  Commands* buff;
+  for(i=0; i < cmdlen; i++, tmp++){
+    if (strcmp(remove_cmd,tmp->cmd) == 0) {
+      buff = tmp;
+      break;
+    }
+  }
+  tmp++;
+  for(int j = i; j < cmdlen-i; j++, tmp++, buff++){
+    buff->cmd = tmp->cmd;
+    buff->msg = tmp->msg;
+  }
+
+  lines--;
+  allCommands = (Commands *)realloc(allCommands, sizeof(Commands)*lines);
+  cmdlen--;
+  return 0;
+}
+
+void list_bot_commands(){ //for debugging
+  int i;
+  Commands* tmp = allCommands;
+  printf("total commands: %d\n", cmdlen);
+  for(i=0; i < cmdlen; i++, tmp++){
+    printf("%s --> %s\n", tmp->cmd, tmp->msg);
+  }
+}
 
 int finish() {
     int i;

--- a/lib/cmdfile.h
+++ b/lib/cmdfile.h
@@ -3,3 +3,4 @@ int test_command(const char *test_cmd, char *outputMsg, int maxOutputLen);
 int finish();
 int remove_command(char* remove_cmd);
 void list_bot_commands();
+int add_command(char* add_cmd, char* add_msg);

--- a/lib/cmdfile.h
+++ b/lib/cmdfile.h
@@ -1,3 +1,5 @@
 int init();
 int test_command(const char *test_cmd, char *outputMsg, int maxOutputLen);
 int finish();
+int remove_command(char* remove_cmd);
+void list_bot_commands();


### PR DESCRIPTION
### new commands:
`[\#channel]> ls`

lists all chat commands, excluding hardcoded commands
`[\#channel]> rmcmd`

removes commands from list of commands

### new methods

`add_command`

Replaces old method of re initializing, which re reads from disk. Addresses issue #34.
`remove_command`

removed command from allCommands struct in memory.
